### PR TITLE
佣金管理编辑 佣金可以编辑

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "axios": "^0.15.3",
     "babel-polyfill": "^6.23.0",
-    "element-ui": "2.0.8",
+    "element-ui": "^2.0.11",
     "vue": "^2.3.2",
     "vue-core-image-upload": "2.1.11",
     "vue-datasource": "1.0.9",

--- a/src/components/page/business/commission.vue
+++ b/src/components/page/business/commission.vue
@@ -54,7 +54,7 @@
                 <template scope="scope">
                     <el-button type="text" size="small" v-bind:class=" scope.row.state == 0 ? '' : 'grey' " @click="handleEdit(scope.$index, scope.row)">编辑</el-button>
                     <el-button type="text" size="small" v-bind:class=" scope.row.returnCommision == 0 && scope.row.state == 0 ? '' : 'grey' " @click="confirmHandle(scope.$index, scope.row)">
-                        <span v-text="scope.row.state == 0 ? '确认还款' : '取消确认'"></span>
+                        <span v-text="scope.row.state == 0 ? '确认处理' : '取消确认'"></span>
                     </el-button>
                 </template>
             </el-table-column>

--- a/src/components/page/business/commission.vue
+++ b/src/components/page/business/commission.vue
@@ -220,7 +220,9 @@
                 this.editItem = {
                     id:row.id,
                     commision:row.commision,
+                    billId:row.billId,
                     userId:row.userId,
+                    remark:row.remark,
                     returnCommision:row.returnCommision,
                     returnedCommision:row.returnedCommision,
                     incomeCommision:row.incomeCommision,

--- a/src/components/page/business/commission.vue
+++ b/src/components/page/business/commission.vue
@@ -53,7 +53,9 @@
             <el-table-column  label="操作"  align="center" width="150" fixed="right">
                 <template scope="scope">
                     <el-button type="text" size="small" v-bind:class=" scope.row.state == 0 ? '' : 'grey' " @click="handleEdit(scope.$index, scope.row)">编辑</el-button>
-                    <el-button type="text" size="small" v-bind:class=" scope.row.returnCommision == 0 && scope.row.state == 0 ? '' : 'grey' " @click="confirmHandle(scope.$index, scope.row)">确认处理</el-button>
+                    <el-button type="text" size="small" v-bind:class=" scope.row.returnCommision == 0 && scope.row.state == 0 ? '' : 'grey' " @click="confirmHandle(scope.$index, scope.row)">
+                        <span v-text="scope.row.state == 0 ? '确认还款' : '取消确认'"></span>
+                    </el-button>
                 </template>
             </el-table-column>
         </el-table>
@@ -83,7 +85,7 @@
                 </el-form-item>
 
                 <el-form-item size="small" label="佣金">
-                    <el-input v-model="editItem.commision" class="row" :disabled="true"></el-input>
+                    <el-input v-model="editItem.commision" class="row"></el-input>
                 </el-form-item>
 
                 <el-form-item size="small" label="待发佣金">
@@ -250,9 +252,11 @@
                 });
             },
             confirmHandle(index, row){
-                if(row.returnCommision != 0 || row.state != 0)return;
+                if (row.returnCommision != 0) return;
+                let str = '是否确认佣金处理?';
+                if(row.state==1) str = '是否取消佣金确认处理?';
                 var self = this;
-                this.$confirm('是否完成佣金处理?', '提示', {
+                this.$confirm(str, '提示', {
                     confirmButtonText: '确定',
                     cancelButtonText: '取消',
                     type: 'warning'

--- a/src/components/page/business/commission.vue
+++ b/src/components/page/business/commission.vue
@@ -158,7 +158,7 @@
         methods:{
             handleSizeChange(val){
                 this.searchInfo.count = val;
-                this.pageNo = 1;
+                this.triggerSearch();
             },
             handleCurrentChange(val){
                 this.pageNo = val;

--- a/src/components/page/business/deposit.vue
+++ b/src/components/page/business/deposit.vue
@@ -46,7 +46,7 @@
                 <template scope="scope">
                     <el-button type="text" size="small" v-bind:class=" scope.row.state == 0 ? '' : 'grey' " @click="handleEdit(scope.$index, scope.row)">编辑</el-button>
                     <el-button type="text" size="small" v-bind:class=" scope.row.returnBail == 0 && scope.row.state == 0 ? '' : 'grey' " @click="confirmHandle(scope.$index, scope.row)">
-                        <span v-text="scope.row.state == 0 ? '确认还款' : '取消确认'"></span>
+                        <span v-text="scope.row.state == 0 ? '确认处理' : '取消确认'"></span>
                     </el-button>
                 </template>
             </el-table-column>

--- a/src/components/page/business/deposit.vue
+++ b/src/components/page/business/deposit.vue
@@ -66,7 +66,7 @@
             <el-form :model="editItem" :rules="rules" ref="editItem" :label-position="'right'" label-width="150px" inline-message>
 
                 <el-form-item size="small" label="保证金">
-                    <el-input :value="editItem.bail" class="row"></el-input>
+                    <el-input v-model="editItem.bail" class="row"></el-input>
                 </el-form-item>
 
                 <el-form-item size="small" label="待退金额">

--- a/src/components/page/business/deposit.vue
+++ b/src/components/page/business/deposit.vue
@@ -29,10 +29,7 @@
                   border
                   max-height="500"
                   :cell-style="{padding:'3px 0'}">
-            <el-table-column label="序号" width="50" scope="scope" align="center" fixed>
-                <template scope="scope">
-                    <span v-text="scope.$index+1"></span>
-                </template>
+            <el-table-column label="序号" width="50" scope="scope" align="center" type="index" fixed>
             </el-table-column >
             <el-table-column prop="company.name" label="公司" width="150"  align="center" ></el-table-column>
             <el-table-column prop="customerName" label="姓名"  align="center" ></el-table-column>
@@ -48,7 +45,9 @@
             <el-table-column  label="操作"  align="center" width="120" fixed="right">
                 <template scope="scope">
                     <el-button type="text" size="small" v-bind:class=" scope.row.state == 0 ? '' : 'grey' " @click="handleEdit(scope.$index, scope.row)">编辑</el-button>
-                    <el-button type="text" size="small" v-bind:class=" scope.row.returnBail == 0 && scope.row.state == 0 ? '' : 'grey' " @click="confirmHandle(scope.$index, scope.row)">确认处理</el-button>
+                    <el-button type="text" size="small" v-bind:class=" scope.row.returnBail == 0 && scope.row.state == 0 ? '' : 'grey' " @click="confirmHandle(scope.$index, scope.row)">
+                        <span v-text="scope.row.state == 0 ? '确认还款' : '取消确认'"></span>
+                    </el-button>
                 </template>
             </el-table-column>
         </el-table>
@@ -67,7 +66,7 @@
             <el-form :model="editItem" :rules="rules" ref="editItem" :label-position="'right'" label-width="150px" inline-message>
 
                 <el-form-item size="small" label="保证金">
-                    <el-input :value="editItem.bail" class="row" :disabled="true"></el-input>
+                    <el-input :value="editItem.bail" class="row"></el-input>
                 </el-form-item>
 
                 <el-form-item size="small" label="待退金额">
@@ -168,7 +167,7 @@
                             } else {
                                 return prev;
                             }
-                        }, 0);
+                        }, 0).toFixed(2);
                         sums[index] += ' 元';
                     } else {
                         sums[index] = '';
@@ -232,9 +231,11 @@
                 });
             },
             confirmHandle(index, row){
-                if(row.returnBail != 0 || row.state != 0)return;
+                if (row.returnBail != 0) return;
+                let str = '是否完成保证金处理?';
+                if(row.state==1) str = '是否取消保证金确认处理?';
                 var self = this;
-                this.$confirm('是否完成保证金处理?', '提示', {
+                this.$confirm(str, '提示', {
                     confirmButtonText: '确定',
                     cancelButtonText: '取消',
                     type: 'warning'

--- a/src/components/page/business/loans.vue
+++ b/src/components/page/business/loans.vue
@@ -327,7 +327,7 @@
                             <el-input v-model="bailItem.remark" :disabled="true" class="row"></el-input>
                         </el-form-item>
                         <el-form-item size="small" label="保证金" >
-                            <el-input :value="bailItem.bail" :disabled="true" class="row"></el-input>
+                            <el-input :value="bailItem.bail" class="row"></el-input>
                         </el-form-item>
                         <el-form-item size="small" label="待退金额" >
                             <el-input :value="returnBail" class="row" :disabled="true"></el-input>
@@ -469,7 +469,7 @@
                             } else {
                                 return prev;
                             }
-                        }, 0);
+                        }, 0).toFixed(2);
                         sums[index] += ' 元';
                     } else {
                         sums[index] = '';

--- a/src/components/page/business/repayment.vue
+++ b/src/components/page/business/repayment.vue
@@ -17,6 +17,26 @@
                         :value="item.id"
                     ></el-option>
                 </el-select>
+                <span class="search-label">贷款时间</span>
+                <el-date-picker
+                    class="frame"
+                    :editable="false"
+                    value-format="yyyy-MM-dd"
+                    v-model="searchInfo.loanStartDate"
+                    type="date"
+                    size="small"
+                    placeholder="开始时间">
+                </el-date-picker>
+                <span>-</span>
+                <el-date-picker
+                    class="frame"
+                    :editable="false"
+                    value-format="yyyy-MM-dd"
+                    v-model="searchInfo.loanEndDate"
+                    type="date"
+                    size="small"
+                    placeholder="结束时间">
+                </el-date-picker>
                 <span class="search-label">还款时间</span>
                 <el-date-picker
                     class="frame"
@@ -146,7 +166,9 @@
                     companyId:'',
                     state:'',
                     startDate:'',
-                    endDate:''
+                    endDate:'',
+                    loanStartDate:'',
+                    loanEndDate:''
                 },
                 tableData:[],
                 multipleSelection:[],
@@ -230,6 +252,13 @@
                     this.$message.error('结束时间需大于开始时间');
                     this.searchInfo.startDate = '';
                     this.searchInfo.endDate = '';
+                    return;
+                }
+                if( this.searchInfo.loanStartDate!='' && this.searchInfo.loanEndDate!= ''
+                    && new Date(this.searchInfo.loanEndDate) - new Date(this.searchInfo.loanStartDate) < 0 ){
+                    this.$message.error('结束时间需大于开始时间');
+                    this.searchInfo.loanStartDate = '';
+                    this.searchInfo.loanEndDate = '';
                     return;
                 }
                 resource.repaymentList(this.searchInfo,function(result){

--- a/src/components/page/business/repayment.vue
+++ b/src/components/page/business/repayment.vue
@@ -67,11 +67,8 @@
                 width="55">
             </el-table-column>
 
-            <el-table-column label="序号" width="50" scope="scope" align="center">
-                <template scope="scope">
-                    <span v-text="scope.$index+1"></span>
-                </template>
-            </el-table-column >
+            <el-table-column label="序号" width="50" scope="scope" type="index" align="center" fixed>
+            </el-table-column>
             <el-table-column prop="company.name" label="公司" width="150"  align="center" ></el-table-column>
             <el-table-column prop="customerName" label="姓名" width="80"  align="center" ></el-table-column>
             <el-table-column prop="phone" label="手机" width="150"  align="center" ></el-table-column>
@@ -87,7 +84,9 @@
             <el-table-column  label="操作" width="120" align="center" fixed="right">
                 <template scope="scope">
                     <el-button type="text" v-bind:class=" scope.row.state == 0 ? '' : 'grey' " size="small" @click="handleEdit(scope.$index, scope.row)">编辑</el-button>
-                    <el-button type="text" v-bind:class=" scope.row.state == 0 ? '' : 'grey' " @click="confirmRepayment(scope.$index, scope.row)">确认还款</el-button>
+                    <el-button type="text" v-bind:class=" scope.row.state == 0 ? '' : 'grey' " @click="confirmRepayment(scope.$index, scope.row)">
+                        <span v-text="scope.row.state == 0 ? '确认还款' : '取消确认'"></span>
+                    </el-button>
                 </template>
             </el-table-column>
 
@@ -215,7 +214,7 @@
                             } else {
                                 return prev;
                             }
-                        }, 0);
+                        }, 0).toFixed(2);
                         sums[index] += ' 元';
                     } else {
                         sums[index] = '';
@@ -285,9 +284,10 @@
                 });
             },
             confirmRepayment(index,row){
-                if(row.state==1)return;
+                let str = '是否确认还款?';
+                if(row.state==1) str = '是否取消确认还款?';
                 let self = this;
-                this.$confirm('是否确认还款?', '提示', {
+                this.$confirm(str, '提示', {
                     confirmButtonText: '确定',
                     cancelButtonText: '取消',
                     type: 'warning'

--- a/src/components/page/customer/customer.vue
+++ b/src/components/page/customer/customer.vue
@@ -648,6 +648,7 @@
                                 type: 'success'
                             });
                             self.batchUpdateSalesmanDialog = false;
+                            self.search();
                         }else{
                             self.$message.error(result.msg);
                         }


### PR DESCRIPTION
保证金管理编辑 保证金可以编辑（2个地方）
还款、保证金、佣金增加反确认功能(仅列表、仅管理员、放在上面)
所有合计四舍五入两位
批量更换业务员页面没有刷新